### PR TITLE
Initial PR

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -2,7 +2,7 @@
   "template": "https://github.com/hypothesis/cookiecutters",
   "checkout": null,
   "directory": "pypackage",
-  "ignore": [],
+  "ignore": ["src/h_testkit/core.py", "tests/unit/h_testkit/core_test.py"],
   "extra_context": {
     "name": "h-testkit",
     "package_name": "h_testkit",

--- a/.cookiecutter/includes/coverage/omit
+++ b/.cookiecutter/includes/coverage/omit
@@ -1,0 +1,3 @@
+"*/h_testkit/__init__.py",
+"*/h_testkit/factoryboy.py",
+"*/h_testkit/pytest_plugin.py",

--- a/.cookiecutter/includes/pylint/disables
+++ b/.cookiecutter/includes/pylint/disables
@@ -1,0 +1,1 @@
+"import-outside-toplevel",

--- a/.cookiecutter/includes/pyproject.toml
+++ b/.cookiecutter/includes/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "h-testkit"
+dynamic = ["description", "version", "urls", "requires-python", "readme", "dependencies"]
+classifiers = [
+    "Framework :: Pytest",
+]
+
+[project.entry-points.pytest11]
+myproject = "h_testkit.pytest_plugin"

--- a/.cookiecutter/includes/tox/deps
+++ b/.cookiecutter/includes/tox/deps
@@ -1,0 +1,1 @@
+{dev,tests,functests,lint}: sqlalchemy>2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ parallel = true
 source = ["h_testkit", "tests/unit"]
 omit = [
     "*/h_testkit/__main__.py",
+    "*/h_testkit/__init__.py",
+    "*/h_testkit/factoryboy.py",
+    "*/h_testkit/pytest_plugin.py",
 ]
 
 [tool.coverage.paths]
@@ -127,6 +130,8 @@ disable = [
 
     # Issues to disable this for false positives, disabling it globally in the meantime https://github.com/PyCQA/pylint/issues/214
     "duplicate-code",
+
+    "import-outside-toplevel",
 ]
 
 good-names = [
@@ -141,3 +146,13 @@ score = "no"
 [tool.hdev]
 project_name = "h-testkit"
 project_type = "library"
+
+[project]
+name = "h-testkit"
+dynamic = ["description", "version", "urls", "requires-python", "readme", "dependencies"]
+classifiers = [
+    "Framework :: Pytest",
+]
+
+[project.entry-points.pytest11]
+myproject = "h_testkit.pytest_plugin"

--- a/src/h_testkit/__init__.py
+++ b/src/h_testkit/__init__.py
@@ -1,0 +1,1 @@
+from h_testkit.factoryboy import set_factoryboy_sqlalchemy_session

--- a/src/h_testkit/core.py
+++ b/src/h_testkit/core.py
@@ -1,2 +1,0 @@
-def hello_world():
-    return "Hello, world!"

--- a/src/h_testkit/factoryboy.py
+++ b/src/h_testkit/factoryboy.py
@@ -1,0 +1,14 @@
+import tests  # pylint:disable=import-error
+
+
+def set_factoryboy_sqlalchemy_session(db_session):
+    from factory.alchemy import SQLAlchemyModelFactory
+
+    sqlalchemy_factory_classes = [
+        class_
+        for class_ in tests.factories.__dict__.values()
+        if isinstance(class_, type) and issubclass(class_, SQLAlchemyModelFactory)
+    ]
+
+    for class_ in sqlalchemy_factory_classes:
+        class_._meta.sqlalchemy_session = db_session  # pylint:disable=protected-access

--- a/src/h_testkit/pytest_plugin.py
+++ b/src/h_testkit/pytest_plugin.py
@@ -1,0 +1,60 @@
+from os import environ
+
+import pytest
+
+from h_testkit.factoryboy import set_factoryboy_sqlalchemy_session
+
+
+@pytest.fixture(scope="session")
+def db_engine():
+    """Return the SQLAlchemy database engine."""
+    from sqlalchemy import create_engine
+
+    return create_engine(environ["DATABASE_URL"])
+
+
+@pytest.fixture(scope="session")
+def db_sessionfactory():
+    """Return the SQLAlchemy session factory."""
+    from sqlalchemy.orm import sessionmaker
+
+    return sessionmaker()
+
+
+@pytest.fixture
+def db_session(db_engine, db_sessionfactory):  # pylint:disable=redefined-outer-name
+    """Return the SQLAlchemy database session.
+
+    This returns a session that is wrapped in an external transaction that is
+    rolled back after each test, so tests can't make database changes that
+    affect later tests.  Even if the test (or the code under test) calls
+    session.commit() this won't touch the external transaction.
+
+    This is the same technique as used in SQLAlchemy's own CI:
+    https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites
+    """
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    db_session = db_sessionfactory(  # pylint:disable=redefined-outer-name
+        bind=connection, join_transaction_mode="create_savepoint"
+    )
+    set_factoryboy_sqlalchemy_session(db_session)
+
+    yield db_session
+
+    db_session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def factory_boy_random_seed():
+    """Set factory_boy's random seed.
+
+    Set factory_boy's random seed so that it produces the same random values
+     in each run of the tests. See:
+     https://factoryboy.readthedocs.io/en/latest/index.html#reproducible-random-values
+    """
+    import factory.random
+
+    factory.random.reseed_random("hypothesis/h-testkit")

--- a/tests/unit/h_testkit/core_test.py
+++ b/tests/unit/h_testkit/core_test.py
@@ -1,6 +1,0 @@
-from h_testkit.core import hello_world
-
-
-class TestHelloWorld:
-    def test_it(self):
-        assert hello_world() == "Hello, world!"

--- a/tests/unit/h_testkit/test_it.py
+++ b/tests/unit/h_testkit/test_it.py
@@ -1,0 +1,2 @@
+def test_it():
+    assert True

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ deps =
     lint,tests,functests: pytest-factoryboy
     lint,tests,functests: h-matchers
     lint,template: cookiecutter
+    {dev,tests,functests,lint}: sqlalchemy>2
 depends =
     coverage: tests,py{311,310,39,38}-tests
 commands =


### PR DESCRIPTION
Our projects have several pytest fixtures that're duplicated between projects (either exactly the same, or unnecessarily different between projects). h-testkit is a pytest plugin to contain these shared fixtures so that we don't have to implement them in each project.

See https://github.com/hypothesis/via/pull/1265 for an example of how we'll add h-testkit to projects.

In future h-testkit can also contain other stuff for tests besides just pytest fixtures, e.g. anything else that pytest plugins can do (hooks etc), test helper functions (although these are probably best implemented as fixtures that return functions), scripts.